### PR TITLE
@OneToOne 관계에서 발생하는 N+1문제 해결 

### DIFF
--- a/backend/SpringbootServer/src/main/java/Youtube/SpringbootServer/entity/Percent.java
+++ b/backend/SpringbootServer/src/main/java/Youtube/SpringbootServer/entity/Percent.java
@@ -47,9 +47,4 @@ public class Percent {
         this.disgust = disgust;
         this.fear = fear;
     }
-
-    public void addRecord(Record record){
-        this.record = record;
-        record.setPercent(this);
-    }
 }

--- a/backend/SpringbootServer/src/main/java/Youtube/SpringbootServer/entity/Record.java
+++ b/backend/SpringbootServer/src/main/java/Youtube/SpringbootServer/entity/Record.java
@@ -37,9 +37,6 @@ public class Record {
     private List<Keyword> keywords = new ArrayList<>();
 
     @OneToOne(mappedBy = "record", fetch = LAZY)
-    private Percent percent;
-
-    @OneToOne(mappedBy = "record", fetch = LAZY)
     private VideoInformation videoInformation;
 
     @JsonIgnore

--- a/backend/SpringbootServer/src/main/java/Youtube/SpringbootServer/repository/RecordRepository.java
+++ b/backend/SpringbootServer/src/main/java/Youtube/SpringbootServer/repository/RecordRepository.java
@@ -1,6 +1,7 @@
 package Youtube.SpringbootServer.repository;
 
 import Youtube.SpringbootServer.entity.Comment;
+import Youtube.SpringbootServer.entity.Percent;
 import Youtube.SpringbootServer.entity.Record;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
@@ -18,5 +19,6 @@ public interface RecordRepository extends JpaRepository<Record,Long> {
 
     List<Record> findByMemberId(long id);
 
-
+    @Query("select r from Record r join fetch r.videoInformation where r.member.id= :id")
+    List<Record> findRecords(@Param("id") long id);
 }

--- a/backend/SpringbootServer/src/main/java/Youtube/SpringbootServer/service/BoardService.java
+++ b/backend/SpringbootServer/src/main/java/Youtube/SpringbootServer/service/BoardService.java
@@ -93,7 +93,7 @@ public class BoardService {
 
     //분석 리스트 출력.
     public List<Record> findRecords(Long id){
-        List<Record> records = recordRepository.findByMemberId(id);
+        List<Record> records = recordRepository.findRecords(id);
         return records;
     }
 

--- a/backend/SpringbootServer/src/main/java/Youtube/SpringbootServer/service/BoardService.java
+++ b/backend/SpringbootServer/src/main/java/Youtube/SpringbootServer/service/BoardService.java
@@ -65,7 +65,7 @@ public class BoardService {
 
         //percent 저장
         Percent percent = entityConverter.toPercentEntity(percentDTO);
-        percent.addRecord(record);
+        percent.setRecord(record);
         percentRepository.save(percent);
 
         //videoInformation 저장.

--- a/backend/SpringbootServer/src/main/resources/application.yml
+++ b/backend/SpringbootServer/src/main/resources/application.yml
@@ -4,17 +4,17 @@ spring:
 
   datasource:
     driver-class-name: com.mysql.cj.jdbc.Driver
-    url: jdbc:mysql://localhost:3306/user?serverTimezone=Asia/Seoul
-    username: root
-    password: qlalfdlwl1!
+    url: jdbc:mysql://localhost:3306/tothemoon?serverTimezone=Asia/Seoul
+    username: tothemoon
+    password: passwd123
 
   jpa:
     hibernate:
-      ddl-auto: create     # create - 애플리케이션 실행 시점에 내가 가지고 있는 테이블을 다 지우고 재 생성. / none - 안 지우고 계속 사용
+      ddl-auto: update     # create - 애플리케이션 실행 시점에 내가 가지고 있는 테이블을 다 지우고 재 생성. / none - 안 지우고 계속 사용
     properties:
       hibernate:
         default_batch_fetch_size: 100
-      #  show_sql: true     #system.out.print로 출력하는 것
+        show_sql: true     #system.out.print로 출력하는 것
         format_sql: true
         dialect: org.hibernate.dialect.MySQL5InnoDBDialect
 


### PR DESCRIPTION
문제:
![해결 전](https://user-images.githubusercontent.com/70521476/179935173-e15b4a19-608d-482c-a71c-aae6270be133.png)
record를 조회할 때마다 게시물의 수만 큼 videoinformation과 percent의 조회 쿼리 문이 반복 생성되었음.

원인:
OneToOne 관계에서 연관관계 주인이 아닌 곳에서 조회하기 때문에 N+1문제가 발생함. 외래 키를 갖고 있지 않기 때문.
Record 입장에서는 percent와 videoinformation의 외래키가 없기 때문에 null인지 아닌지 알 수 없다. 그래서 프록시 객체 또한 만들 수 없는 것이고 직접 쿼리문이 생성된 것이다. (OneToMany의 경우에는 List형태로 참조함. 빈 컬랙션이 초기화 될 경우 proxy가 생기므로 Lazing Loading 적용이 가능)

해결
percent의 경우 참조할 일이 없기 때문에 단방향 관계로 수정.
videoinformation의 경우 참조 해야 하므로 fetch join을 이용해서 해결.
<img src="https://user-images.githubusercontent.com/70521476/179938352-d35bad76-bd0b-4837-9555-fefb7a9ba265.png" width="400" height="400"/>
